### PR TITLE
Default file pattern and placeholders

### DIFF
--- a/cwsl/core/file_creator.py
+++ b/cwsl/core/file_creator.py
@@ -80,10 +80,7 @@ class FileCreator(DataSet):
         # be in canonical form.
         for constraint in self.constraints:
             if not constraint.values:
-                module_logger.error("Constraint {0} is empty - should be in canonical form!"
-                                    .format(constraint))
-                raise EmptyConstraintError("Constraint {0} is empty - should be in canonical form!"
-                                           .format(constraint))
+                constraint.values = set(['na'])
 
         # A set to hold all the valid combinations of attributes.
         self.valid_combinations = set()

--- a/cwsl/core/file_creator.py
+++ b/cwsl/core/file_creator.py
@@ -78,9 +78,20 @@ class FileCreator(DataSet):
 
         # This object must create files, so after merging all constraints must
         # be in canonical form.
+        # "extra" and "info" are keywords for non-compulsory constraints that 
+        # are replaced by a placeholder value.
         for constraint in self.constraints:
             if not constraint.values:
-                constraint.values = set(['na'])
+                split_key = constraint.key.split('_')
+                if 'extra' in split_key:
+                    constraint.values = set(['noextras'])
+                elif 'info' in split_key:
+                    constraint.values = set(['orig'+split_key[0]])
+                else:
+                    module_logger.error("Constraint {0} is empty - should be in canonical form!"
+                                        .format(constraint))
+                    raise EmptyConstraintError("Constraint {0} is empty - should be in canonical form!"
+                                               .format(constraint))                
 
         # A set to hold all the valid combinations of attributes.
         self.valid_combinations = set()

--- a/cwsl/core/pattern_generator.py
+++ b/cwsl/core/pattern_generator.py
@@ -74,17 +74,31 @@ class PatternGenerator(object):
         return pba_dict
 
     def load_paths(self):
-        """ The patterns live here! """
+        """ The patterns live here. 
+        
+        You should use the "default" pattern unless you have a good reason not to. 
+
+        All fields in a pattern are compulsory (i.e. there must be a constraint matching each) 
+        except for the %x_info% fields (e.g. %lat_info%). If there is no matching constraint a
+        placeholder value is inserted (e.g. %lat_info% becomes "origlat") to indicate that
+        that field is unaltered from the original data file.
+        
+        The %extra_info% field in the default pattern is a good place to store information
+        like the name of your index.
+         
+        """
 
         fullpath_dict = {}
         fullpath_dict["seasonal"] = os.path.join("%mip%/%product%/%grid%/%institute%/%model%/%experiment%/%frequency%/%realm%/%variable%/%ensemble%/",
                                                  "%variable%_%mip_table%_%model%_%experiment%_%ensemble%_%year_start%-%year_end%-%seas_agg%_%grid%.%suffix%")
-        fullpath_dict["monthly_ts"] = os.path.join("%mip%/%product%/%grid%/%institute%/%model%/%experiment%/%frequency%/%realm%/%variable%/%ensemble%/",
-                                                   "%variable%_%mip_table%_%model%_%experiment%_%ensemble%_%year_start%-%year_end%_%grid%.%suffix%")
+        fullpath_dict["monthly_ts"] = os.path.join("%mip%/%product%/%institute%/%model%/%experiment%/%frequency%/%realm%/%variable%/%ensemble%/",
+                                                   "%variable%_%mip_table%_%model%_%experiment%_%ensemble%_%startdate_info%-%enddate_info%_%grid_info%.%suffix%")
         fullpath_dict["seasonal_indices"] = os.path.join("%mip%/%product%/%grid%/%institute%/%model%/%experiment%/%frequency%/%realm%/%variable%/%ensemble%/",
                                                          "%variable%_%mip_table%_%model%_%experiment%_%ensemble%_%year_start%-%year_end%-%seas_agg%_%index%_%grid%.%suffix%")
         fullpath_dict["monthly_indices"] = os.path.join("%mip%/%product%/%grid%/%institute%/%model%/%experiment%/%frequency%/%realm%/%variable%/%ensemble%/",
                                                         "%variable%_%mip_table%_%model%_%experiment%_%ensemble%_%year_start%-%year_end%_%index%_%grid%.%suffix%")
+        fullpath_dict["default"] = os.path.join("%mip%/%product%/%institute%/%model%/%experiment%/%frequency%/%realm%/%variable%/%ensemble%/",
+                                                "%variable%_%mip_table%_%model%_%experiment%_%ensemble%_%startdate_info%-%enddate_info%-%anomaly_info%-%timeagg_info%_%bottomlevel_info%-%toplevel_info%-%levelagg_info%_%westlon_info%-%eastlon_info%-%lonagg_info%_%southlat_info%-%northlat_info%-%latagg_info%_%grid_info%_%extra_info%.%suffix%")
         fullpath_dict["downloaded"] = os.path.join("%mip%/%product%/%institute%/%model%/%experiment%/%frequency%/%realm%/%variable%/%ensemble%/",
                                                    "%variable%_%mip_table%_%model%_%experiment%_%ensemble%_%origstart%-%origend%.nc")
         fullpath_dict["timeseries"] = os.path.join("%mip%/%product%/%institute%/%model%/%experiment%/%frequency%/%realm%/%variable%/%ensemble%/",

--- a/cwsl/vt_modules/vt_nino34.py
+++ b/cwsl/vt_modules/vt_nino34.py
@@ -51,7 +51,7 @@ class IndicesNino34(vistrails_module.Module):
     _output_ports = [('out_dataset', 'csiro.au.cwsl:VtDataSet'),
                      ('out_constraints', basic_modules.String, True)]
     
-    _execution_options = {'required_modules': ['cdo', 'cct', 'nco', 
+    _execution_options = {'required_modules': ['cdo', 'nco', 
                                                'python/2.7.5','python-cdat-lite/6.0rc2-py2.7.5']}
 
     def __init__(self):
@@ -62,7 +62,7 @@ class IndicesNino34(vistrails_module.Module):
         tools_base_path = configuration.cwsl_ctools_path
         self.command = '${CWSL_CTOOLS}/indices/nino34.sh'
         #Output file structure declaration 
-        self.out_pattern = PatternGenerator('user', 'monthly_indices').pattern
+        self.out_pattern = PatternGenerator('user', 'default').pattern
         
         # Set up the output command for this module, adding extra options.
         self.positional_args = [('year_start', 2), ('year_end', 3)]
@@ -71,8 +71,18 @@ class IndicesNino34(vistrails_module.Module):
 
         # Required input
         in_dataset = self.getInputFromPort("in_dataset")
-        
-        new_cons = set([Constraint('index', ['nino34'])])
+
+        new_cons = set([Constraint('extra_info', ['nino34']),
+                        Constraint('southlat_info', ['5S']),
+                        Constraint('northlat_info', ['5N']),
+                        Constraint('latagg_info', ['fldavg']),
+                        Constraint('westlon_info', ['190E']),
+                        Constraint('eastlon_info', ['240E']),
+                        Constraint('lonagg_info', ['fldavg']),
+                        Constraint('toplevel_info', ['surface']),
+                        Constraint('bottomlevel_info', ['surface']),
+                        Constraint('anomaly_info', ['anom-wrt-unknown']),
+                       ])
         
         cons_for_output = new_cons
         

--- a/cwsl/vt_modules/vt_plot_timeseries.py
+++ b/cwsl/vt_modules/vt_plot_timeseries.py
@@ -67,7 +67,7 @@ class PlotTimeSeries(vistrails_module.Module):
         # Get the output pattern using the PatternGenerator object.
         # Gets the user infomation / authoritative path etc from the
         # user configuration.
-        self.out_pattern = PatternGenerator('user', 'monthly_indices').pattern
+        self.out_pattern = PatternGenerator('user', 'default').pattern
 
     def compute(self):
 

--- a/cwsl/vt_modules/vt_xmltonc.py
+++ b/cwsl/vt_modules/vt_xmltonc.py
@@ -66,7 +66,7 @@ class XmlToNc(vistrails_module.Module):
         tools_base_path = configuration.cwsl_ctools_path
         self.command = '${CWSL_CTOOLS}/utils/xml_to_nc.py'
         #Output file structure declaration ??
-        self.out_pattern = PatternGenerator('user', 'monthly_ts').pattern
+        self.out_pattern = PatternGenerator('user', 'default').pattern
         
         # Set up the output command for this module, adding extra options.
         self.positional_args = [('variable', 0), ('--force', -1, 'raw')]
@@ -80,10 +80,9 @@ class XmlToNc(vistrails_module.Module):
         year_start = self.getInputFromPort("start_year")
         year_end = self.getInputFromPort("end_year")
         
-        new_cons = set([Constraint('year_start', [year_start]),
-                        Constraint('year_end', [year_end]),
-                        Constraint('suffix', ['nc']),
-                        Constraint('grid', ['native'])])
+        new_cons = set([Constraint('startdate_info', [year_start]),
+                        Constraint('enddate_info', [year_end]),
+                        Constraint('suffix', ['nc']),])
 
         cons_for_output = new_cons
 


### PR DESCRIPTION
@captainceramic I've implemented the idea we had earlier today to have a default file pattern and placeholders for certain fields. Couple of points:
* The `mash_lat.py`-style modules we talked about weren't going to work because that makes it impossible to update the latitude field (for example) later on (e.g. if you crop early in a workflow and set the lat field to `5S-5N` and then later on in a workflow take the meridional maximum, there's no way to put the word `mermax` in the latitude field without overwriting the `5S-5N` bit). In other words, I've had to include lots of placeholders, but I think we'll just have to deal with that (the filenames are long already - what's a few more characters!).
* You'll see in this PR that I've altered the relevant scripts associated with the [example nino34 workflow](https://github.com/CWSL/cwsl-mas/wiki/Tutorial). I ran that workflow successfully a number of times during the development process but right now it throws an error at the "Timeslice" stage (see below). This error really has me stumped, so I was wondering if you had any insights?

```
Traceback (most recent call last):
  File "/opt/cloudapps/vistrails/2.1.2/vistrails/core/modules/vistrails_module.py", line 400, in update
    self.compute()
  File "/home/599/dbi599/.vistrails/userpackages/cwsl/vt_modules/vt_xmltonc.py", line 101, in compute
    raise vistrails_module.ModuleError(self, e.output)
AttributeError: 'exceptions.KeyError' object has no attribute 'output'
```  

 