### PR TITLE
Field aggregation module

### DIFF
--- a/cwsl/init.py
+++ b/cwsl/init.py
@@ -37,6 +37,7 @@ from cwsl.vt_modules.vt_nino34 import IndicesNino34
 from cwsl.vt_modules.vt_general_command_pattern import GeneralCommandPattern
 from cwsl.vt_modules.vt_constraintbuilder import ConstraintBuilder
 from cwsl.vt_modules.vt_plot_timeseries import PlotTimeSeries
+from cwsl.vt_modules.vt_field_agg import FieldAggregation
 from cwsl.vt_modules.imageviewer import ImageViewerPanel
 from cwsl.vt_modules.cmip5_constraints import CMIP5Constraints
 from cwsl.vt_modules.sdm_extract import SDMDataExtract
@@ -81,6 +82,8 @@ def initialize(*args, **keywords):
                    namespace='Aggregation')
     reg.add_module(Climatology, name="Climatology",
                    namespace='Aggregation')
+    reg.add_module(FieldAggregation, name="Field Aggregation",
+                   namespace="Aggregation")
 
     #Change
     reg.add_module(TimesliceChange, name="Timeslice Change",

--- a/cwsl/vt_modules/vt_field_agg.py
+++ b/cwsl/vt_modules/vt_field_agg.py
@@ -44,22 +44,19 @@ class FieldAggregation(vistrails_module.Module):
     
     _execution_options = {'required_modules': ['cdo',]}
 
-    _data_type = 'default'
-
     command = '${CWSL_CTOOLS}/aggregation/cdo_field_agg.sh'
-    keyword_args = {}
 
     def __init__(self):
 
         super(FieldAggregation, self).__init__()
-        self.out_pattern = PatternGenerator('user', self._data_type).pattern
+        self.out_pattern = PatternGenerator('user', 'default').pattern
 
     def compute(self):
 
         in_dataset = self.getInputFromPort('in_dataset')
         method = self.getInputFromPort('method')
 
-        self.positional_args = [('method', 0), ]
+        self.positional_args = [(method, 0, 'raw'), ]
         self.keyword_args = {}
 
         if len(method.split(',')) > 1:
@@ -81,8 +78,8 @@ class FieldAggregation(vistrails_module.Module):
 
         try:
             this_process.execute(simulate=configuration.simulate_execution)
-        except subprocess.CalledProcessError, e:
-            raise vistrails_module.ModuleError(self, e.output)
+        except Exception as e:
+            raise vistrails_module.ModuleError(self, repr(e))
             
         process_output = this_process.file_creator
 

--- a/cwsl/vt_modules/vt_field_agg.py
+++ b/cwsl/vt_modules/vt_field_agg.py
@@ -42,7 +42,7 @@ class FieldAggregation(vistrails_module.Module):
 
     _output_ports = [('out_dataset', 'csiro.au.cwsl:VtDataSet')]
     
-    _execution_options = {'required_modules': ['cdo',]}
+    _execution_options = {'required_modules': ['cdo', 'python/2.7.5', 'python-cdat-lite/6.0rc2-py2.7.5']}
 
     command = '${CWSL_CTOOLS}/aggregation/cdo_field_agg.sh'
 
@@ -66,6 +66,7 @@ class FieldAggregation(vistrails_module.Module):
 
         new_constraints_for_output = set([Constraint('lonagg_info', [agg_constraint]),
                                           Constraint('latagg_info', [agg_constraint]),
+                                          Constraint('suffix', ['nc']),
                                           ])
         
         this_process = ProcessUnit([in_dataset],

--- a/cwsl/vt_modules/vt_field_agg.py
+++ b/cwsl/vt_modules/vt_field_agg.py
@@ -1,0 +1,90 @@
+"""
+Authors:  Damien Irving (irving.damien@gmail.com)
+
+Copyright 2015 CSIRO
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This module wraps a shell script that performs field aggregation: 
+cwsl-ctools/aggregation/cdo_field_agg.sh
+
+Part of the CWSLab Model Analysis Service VisTrails plugin.
+
+"""
+
+import subprocess
+from vistrails.core.modules import vistrails_module, basic_modules
+
+from cwsl.configuration import configuration
+from cwsl.core.constraint import Constraint
+from cwsl.core.process_unit import ProcessUnit
+from cwsl.core.pattern_generator import PatternGenerator
+
+
+class FieldAggregation(vistrails_module.Module):
+    """This module performs field aggregation.
+
+    It wraps the cwsl-ctools/aggregation/cdo_field_agg.sh script.
+
+    """
+
+    _input_ports = [('in_dataset', 'csiro.au.cwsl:VtDataSet'),
+                    ('method', basic_modules.String),
+                   ]
+
+    _output_ports = [('out_dataset', 'csiro.au.cwsl:VtDataSet')]
+    
+    _execution_options = {'required_modules': ['cdo',]}
+
+    _data_type = 'default'
+
+    command = '${CWSL_CTOOLS}/aggregation/cdo_field_agg.sh'
+    keyword_args = {}
+
+    def __init__(self):
+
+        super(FieldAggregation, self).__init__()
+        self.out_pattern = PatternGenerator('user', self._data_type).pattern
+
+    def compute(self):
+
+        in_dataset = self.getInputFromPort('in_dataset')
+        method = self.getInputFromPort('method')
+
+        self.positional_args = [('method', 0), ]
+        self.keyword_args = {}
+
+        if len(method.split(',')) > 1:
+            agg_constraint = "".join(method.split(','))
+        else:
+            agg_constraint = method
+
+        new_constraints_for_output = set([Constraint('lonagg_info', [agg_constraint]),
+                                          Constraint('latagg_info', [agg_constraint]),
+                                          ])
+        
+        this_process = ProcessUnit([in_dataset],
+                                   self.out_pattern,
+                                   self.command,
+                                   new_constraints_for_output,
+                                   execution_options=self._execution_options,
+                                   positional_args=self.positional_args,
+                                   cons_keywords=self.keyword_args)
+
+        try:
+            this_process.execute(simulate=configuration.simulate_execution)
+        except subprocess.CalledProcessError, e:
+            raise vistrails_module.ModuleError(self, e.output)
+            
+        process_output = this_process.file_creator
+
+        self.setResult('out_dataset', process_output)
+


### PR DESCRIPTION
I've been working on a whole bunch of new modules at my [cwsl-sandbox repo](https://github.com/DamienIrving/cwsl-sandbox) and before I try and commit them all to the cwsl repo at once, I thought I'd try and implement just one and see if the wrapper I've developed is a suitable template to copy for all my other modules.

This particular module wraps [`cdo_field_agg.sh`](https://github.com/DamienIrving/cwsl-ctools/blob/master/aggregation/cdo_field_agg.sh) and when I try to run [this workflow](https://github.com/DamienIrving/cwsl-workflows/blob/master/fldagg_trail.vt) I get the following error message:
```
Traceback (most recent call last):
  File "/opt/cloudapps/vistrails/2.1.2/vistrails/core/modules/vistrails_module.py", line 400, in update
    self.compute()
  File "/home/599/dbi599/.vistrails/userpackages/cwsl/vt_modules/vt_field_agg.py", line 83, in compute
    this_process.execute(simulate=configuration.simulate_execution)
  File "/home/599/dbi599/.vistrails/userpackages/cwsl/core/process_unit.py", line 299, in execute
    final_command_list = self.apply_positional_args(keyword_command_list, this_dict)
  File "/home/599/dbi599/.vistrails/userpackages/cwsl/core/process_unit.py", line 339, in apply_positional_args
    this_att_value = constraint_dict[arg_name]
KeyError: 'method'
```

I'm wondering (a) why this error is happening (do my positional arguments need to have the same name as the constraints??) and (b) does my wrapper ([`vt_field_agg.py`](https://github.com/DamienIrving/cwsl-mas/blob/devel/cwsl/vt_modules/vt_field_agg.py)) look good as a template to copy for others?
