### PR TITLE
Wrapper for dataset arithmetic script

### DIFF
--- a/cwsl/init.py
+++ b/cwsl/init.py
@@ -42,6 +42,7 @@ from cwsl.vt_modules.vt_meridional_agg import MeridionalAggregation
 from cwsl.vt_modules.vt_zonal_agg import ZonalAggregation
 from cwsl.vt_modules.vt_vertical_agg import VerticalAggregation
 from cwsl.vt_modules.vt_remap import Remap
+from cwsl.vt_modules.vt_dataset_arithmetic import DatasetArithmetic
 from cwsl.vt_modules.imageviewer import ImageViewerPanel
 from cwsl.vt_modules.cmip5_constraints import CMIP5Constraints
 from cwsl.vt_modules.sdm_extract import SDMDataExtract
@@ -116,6 +117,8 @@ def initialize(*args, **keywords):
     reg.add_module(GeneralCommandPattern, name='General Command Line Program',
                    namespace='Utilities')
     reg.add_module(Remap, name='Remap horizontal grid',
+                   namespace='Utilities')
+    reg.add_module(DatasetArithmetic, name='Dataset Arithmetic',
                    namespace='Utilities')
 
     # Statistical Downscaling.

--- a/cwsl/vt_modules/vt_dataset_arithmetic.py
+++ b/cwsl/vt_modules/vt_dataset_arithmetic.py
@@ -61,11 +61,11 @@ class DatasetArithmetic(vistrails_module.Module):
         self.positional_args = [(operation, 0, 'raw'), ]
         self.keyword_args = {}
 
-        new_constraints_for_output = set([Constraint('extra_info', [method]),
+        new_constraints_for_output = set([Constraint('extra_info', [operation]),
                                           Constraint('suffix', ['nc']),
                                           ])
         
-        this_process = ProcessUnit([in_dataset],
+        this_process = ProcessUnit([in_dataset1, in_dataset2],
                                    self.out_pattern,
                                    self.command,
                                    new_constraints_for_output,

--- a/cwsl/vt_modules/vt_dataset_arithmetic.py
+++ b/cwsl/vt_modules/vt_dataset_arithmetic.py
@@ -1,0 +1,84 @@
+"""
+Authors:  Damien Irving (irving.damien@gmail.com)
+
+Copyright 2015 CSIRO
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This module wraps a shell script that performs simple arithmetic on 
+two datasets: cwsl-ctools/utils/cdo_dataset_arithmetic.sh
+
+Part of the CWSLab Model Analysis Service VisTrails plugin.
+
+"""
+
+import subprocess
+from vistrails.core.modules import vistrails_module, basic_modules
+
+from cwsl.configuration import configuration
+from cwsl.core.constraint import Constraint
+from cwsl.core.process_unit import ProcessUnit
+from cwsl.core.pattern_generator import PatternGenerator
+
+
+class DatasetArithmetic(vistrails_module.Module):
+    """This module performs simple arithmetic on two datasets.
+
+    It wraps the cwsl-ctools/utils/cdo_dataset_arithmetic.sh script.
+
+    """
+
+    _input_ports = [('in_dataset1', 'csiro.au.cwsl:VtDataSet'),
+                    ('in_dataset2', 'csiro.au.cwsl:VtDataSet'),
+                    ('operation', basic_modules.String),
+                   ]
+
+    _output_ports = [('out_dataset', 'csiro.au.cwsl:VtDataSet')]
+    
+    _execution_options = {'required_modules': ['cdo', 'python/2.7.5', 'python-cdat-lite/6.0rc2-py2.7.5']}
+
+    command = '${CWSL_CTOOLS}/utils/cdo_dataset_arithmetic.sh'
+
+    def __init__(self):
+
+        super(DatasetArithmetic, self).__init__()
+        self.out_pattern = PatternGenerator('user', 'default').pattern
+
+    def compute(self):
+
+        in_dataset1 = self.getInputFromPort('in_dataset1')
+        in_dataset2 = self.getInputFromPort('in_dataset2')
+        operation = self.getInputFromPort('operation')
+
+        self.positional_args = [(operation, 0, 'raw'), ]
+        self.keyword_args = {}
+
+        new_constraints_for_output = set([Constraint('extra_info', [method]),
+                                          Constraint('suffix', ['nc']),
+                                          ])
+        
+        this_process = ProcessUnit([in_dataset],
+                                   self.out_pattern,
+                                   self.command,
+                                   new_constraints_for_output,
+                                   execution_options=self._execution_options,
+                                   positional_args=self.positional_args,
+                                   cons_keywords=self.keyword_args)
+
+        try:
+            this_process.execute(simulate=configuration.simulate_execution)
+        except Exception as e:
+            raise vistrails_module.ModuleError(self, repr(e))
+            
+        process_output = this_process.file_creator
+
+        self.setResult('out_dataset', process_output)
+


### PR DESCRIPTION
@captainceramic Here's a module that takes two input files - it will be a nice one for testing your handling of multiple input files.

At the moment when I run it with two separate input datasets, it produces a bit of a strange mix of output results. For instance, if dataset 1 only has one file in it (e.g. `ACCESS1-0`, `rcp45`, `tas`) and dataset 2 has only one file in it (e.g. `MRI-CGCM3`, `rcp45`, `tas`) it will produce four output files:

* `/local/r87/dbi599/tmp/CMIP5/GCM/MRI/MRI-CGCM3/rcp45/mon/atmos/tas/r1i1p1/tas_Amon_MRI-CGCM3_rcp45_*.nc` 
* `/local/r87/dbi599/tmp/CMIP5/GCM/CSIRO-BOM/MRI-CGCM3/rcp45/mon/atmos/tas/r1i1p1/tas_Amon_MRI-CGCM3_rcp45_*.nc`
* `/local/r87/dbi599/tmp/CMIP5/GCM/MRI/ACCESS1-0/rcp45/mon/atmos/tas/r1i1p1/tas_Amon_ACCESS1-0_rcp45_*.nc`
* ` /local/r87/dbi599/tmp/CMIP5/GCM/CSIRO-BOM/ACCESS1-0/rcp45/mon/atmos/tas/r1i1p1/tas_Amon_ACCESS1-0_rcp45_*.nc`

If I try and run the workflow with just one input dataset (with the constraint builder specifying `model = ACCESS1-0, MRI-CGCM3`) then the workflow fails at the merge timeseries step when it gets to the second file (`MRI-CGCM3`). This is not a problem that is unique to this workflow - every workflow I construct where the constraint builder specifies more than one model fails like this.